### PR TITLE
fix compile error on linux(ubuntu)

### DIFF
--- a/io-obs/util/util.hpp
+++ b/io-obs/util/util.hpp
@@ -20,6 +20,7 @@
 #define TRIGGER_MAX_VAL     256.f
 
 #include <string>
+#include <vector>
 
 #ifndef IO_CLIENT /* io-client uses this header, but doesn't doesn't use any obs headers */
 #include <obs-module.h>


### PR DESCRIPTION
fix following compile error:
```
In file included from /home/yuki/Documents/repos/obs-studio/plugins/input-overlay/io-obs/sources/input_history.hpp:10:0,
                 from /home/yuki/Documents/repos/obs-studio/plugins/input-overlay/io-obs/sources/input_history.cpp:9:
/home/yuki/Documents/repos/obs-studio/plugins/input-overlay/io-obs/sources/../util/util.hpp:289:32: error: variable or field ‘GetWindowList’ declared void
 extern void GetWindowList(std::vector<std::string> &windows);
                                ^~~~~~
/home/yuki/Documents/repos/obs-studio/plugins/input-overlay/io-obs/sources/../util/util.hpp:289:32: error: ‘vector’ is not a member of ‘std’
```