### PR TITLE
Linux fixes for Legacy branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,93 @@ target_link_libraries(input-overlay
         ${input-overlay_PLATFORM_DEPS}
         ${UIOHOOK_LIBRARY})
 
+# --- Windows-specific build settings and tasks ---
+if(WIN32)
+    if(MSVC)
+        # Enable Multicore Builds and disable FH4 (to not depend on VCRUNTIME140_1.DLL)
+	    add_definitions(/MP /d2FH4-)
+    endif()
+
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		set(ARCH_NAME "64bit")
+		set(OBS_BUILDDIR_ARCH "build64")
+	else()
+		set(ARCH_NAME "32bit")
+		set(OBS_BUILDDIR_ARCH "build32")
+	endif()
+
+	# --- Release package helper ---
+	# The "release" folder has a structure similar OBS' one on Windows
+	set(RELEASE_DIR "${PROJECT_SOURCE_DIR}/release")
+
+	add_custom_command(TARGET input-overlay POST_BUILD
+		# If config is Release, package release files
+		COMMAND if $<CONFIG:Release>==1 (
+			"${CMAKE_COMMAND}" -E make_directory
+			"${RELEASE_DIR}/data/obs-plugins/input-overlay"
+			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
+
+		COMMAND if $<CONFIG:Release>==1 ("${CMAKE_COMMAND}" -E copy_directory
+			"${PROJECT_SOURCE_DIR}/data"
+			"${RELEASE_DIR}/data/obs-plugins/input-overlay")
+
+		COMMAND if $<CONFIG:Release>==1 ("${CMAKE_COMMAND}" -E copy
+			"$<TARGET_FILE:input-overlay>"
+			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
+
+		# In Release mode, copy Qt image format plugins
+		COMMAND if $<CONFIG:Release>==1 (
+			"${CMAKE_COMMAND}" -E copy
+			"${QTDIR}/plugins/imageformats/qjpeg.dll"
+			"${RELEASE_DIR}/bin/${ARCH_NAME}/imageformats/qjpeg.dll")
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 (
+			"${CMAKE_COMMAND}" -E copy
+			"${QTDIR}/plugins/imageformats/qjpeg.dll"
+			"${RELEASE_DIR}/bin/${ARCH_NAME}/imageformats/qjpeg.dll")
+
+		# If config is RelWithDebInfo, package release files
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 (
+			"${CMAKE_COMMAND}" -E make_directory
+			"${RELEASE_DIR}/data/obs-plugins/input-overlay"
+			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
+
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy_directory
+			"${PROJECT_SOURCE_DIR}/data"
+			"${RELEASE_DIR}/data/obs-plugins/input-overlay")
+
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy
+			"$<TARGET_FILE:input-overlay>"
+			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
+
+		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy
+			"$<TARGET_PDB_FILE:input-overlay>"
+			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
+
+		# Copy to obs-studio dev environment for immediate testing
+		COMMAND if $<CONFIG:Debug>==1 (
+			"${CMAKE_COMMAND}" -E copy
+				"$<TARGET_FILE:input-overlay>"
+				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/obs-plugins/${ARCH_NAME}")
+
+		COMMAND if $<CONFIG:Debug>==1 (
+			"${CMAKE_COMMAND}" -E copy
+				"$<TARGET_PDB_FILE:input-overlay>"
+				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/obs-plugins/${ARCH_NAME}")
+
+		COMMAND if $<CONFIG:Debug>==1 (
+			"${CMAKE_COMMAND}" -E make_directory
+				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/data/obs-plugins/input-overlay")
+
+		COMMAND if $<CONFIG:Debug>==1 (
+			"${CMAKE_COMMAND}" -E copy_directory
+				"${PROJECT_SOURCE_DIR}/data"
+				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/data/obs-plugins/input-overlay")
+	)
+	# --- End of sub-section ---
+
+endif()
+# --- End of section ---
+
 # --- Linux-specific build settings and tasks ---
 if(UNIX AND NOT APPLE)
 	include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
-project(input-overlay)
+cmake_minimum_required(VERSION 3.5)
+project(input-overlay VERSION 4.9)
 
 find_path(UIOHOOK_INCLUDE_DIR uiohook.h)
 find_library(UIOHOOK_LIBRARY uiohook)
+find_package(LibObs REQUIRED)
 
 if (MSVC)
     set(input-overlay_PLATFORM_DEPS
@@ -48,4 +50,22 @@ target_link_libraries(input-overlay
         ${input-overlay_PLATFORM_DEPS}
         ${UIOHOOK_LIBRARY})
 
-install_obs_plugin_with_data(input-overlay data)
+# --- Linux-specific build settings and tasks ---
+if(UNIX AND NOT APPLE)
+	include(GNUInstallDirs)
+
+	set_target_properties(input-overlay PROPERTIES PREFIX "")
+
+	file(GLOB locale_files data/locale/*.ini)
+
+        set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
+		OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+	install(TARGETS input-overlay LIBRARY
+		DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins"
+		PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+
+	install(FILES ${locale_files}
+		DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/input-overlay/locale")
+endif()
+# --- End of section ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,109 +50,25 @@ target_link_libraries(input-overlay
         ${input-overlay_PLATFORM_DEPS}
         ${UIOHOOK_LIBRARY})
 
-# --- Windows-specific build settings and tasks ---
-if(WIN32)
-    if(MSVC)
-        # Enable Multicore Builds and disable FH4 (to not depend on VCRUNTIME140_1.DLL)
-	    add_definitions(/MP /d2FH4-)
-    endif()
-
-	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-		set(ARCH_NAME "64bit")
-		set(OBS_BUILDDIR_ARCH "build64")
-	else()
-		set(ARCH_NAME "32bit")
-		set(OBS_BUILDDIR_ARCH "build32")
-	endif()
-
-	# --- Release package helper ---
-	# The "release" folder has a structure similar OBS' one on Windows
-	set(RELEASE_DIR "${PROJECT_SOURCE_DIR}/release")
-
-	add_custom_command(TARGET input-overlay POST_BUILD
-		# If config is Release, package release files
-		COMMAND if $<CONFIG:Release>==1 (
-			"${CMAKE_COMMAND}" -E make_directory
-			"${RELEASE_DIR}/data/obs-plugins/input-overlay"
-			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
-
-		COMMAND if $<CONFIG:Release>==1 ("${CMAKE_COMMAND}" -E copy_directory
-			"${PROJECT_SOURCE_DIR}/data"
-			"${RELEASE_DIR}/data/obs-plugins/input-overlay")
-
-		COMMAND if $<CONFIG:Release>==1 ("${CMAKE_COMMAND}" -E copy
-			"$<TARGET_FILE:input-overlay>"
-			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
-
-		# In Release mode, copy Qt image format plugins
-		COMMAND if $<CONFIG:Release>==1 (
-			"${CMAKE_COMMAND}" -E copy
-			"${QTDIR}/plugins/imageformats/qjpeg.dll"
-			"${RELEASE_DIR}/bin/${ARCH_NAME}/imageformats/qjpeg.dll")
-		COMMAND if $<CONFIG:RelWithDebInfo>==1 (
-			"${CMAKE_COMMAND}" -E copy
-			"${QTDIR}/plugins/imageformats/qjpeg.dll"
-			"${RELEASE_DIR}/bin/${ARCH_NAME}/imageformats/qjpeg.dll")
-
-		# If config is RelWithDebInfo, package release files
-		COMMAND if $<CONFIG:RelWithDebInfo>==1 (
-			"${CMAKE_COMMAND}" -E make_directory
-			"${RELEASE_DIR}/data/obs-plugins/input-overlay"
-			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
-
-		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy_directory
-			"${PROJECT_SOURCE_DIR}/data"
-			"${RELEASE_DIR}/data/obs-plugins/input-overlay")
-
-		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy
-			"$<TARGET_FILE:input-overlay>"
-			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
-
-		COMMAND if $<CONFIG:RelWithDebInfo>==1 ("${CMAKE_COMMAND}" -E copy
-			"$<TARGET_PDB_FILE:input-overlay>"
-			"${RELEASE_DIR}/obs-plugins/${ARCH_NAME}")
-
-		# Copy to obs-studio dev environment for immediate testing
-		COMMAND if $<CONFIG:Debug>==1 (
-			"${CMAKE_COMMAND}" -E copy
-				"$<TARGET_FILE:input-overlay>"
-				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/obs-plugins/${ARCH_NAME}")
-
-		COMMAND if $<CONFIG:Debug>==1 (
-			"${CMAKE_COMMAND}" -E copy
-				"$<TARGET_PDB_FILE:input-overlay>"
-				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/obs-plugins/${ARCH_NAME}")
-
-		COMMAND if $<CONFIG:Debug>==1 (
-			"${CMAKE_COMMAND}" -E make_directory
-				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/data/obs-plugins/input-overlay")
-
-		COMMAND if $<CONFIG:Debug>==1 (
-			"${CMAKE_COMMAND}" -E copy_directory
-				"${PROJECT_SOURCE_DIR}/data"
-				"${LIBOBS_INCLUDE_DIR}/../${OBS_BUILDDIR_ARCH}/rundir/$<CONFIG>/data/obs-plugins/input-overlay")
-	)
-	# --- End of sub-section ---
-
-endif()
-# --- End of section ---
-
-# --- Linux-specific build settings and tasks ---
 if(UNIX AND NOT APPLE)
-	include(GNUInstallDirs)
+    # This makes it possible to build this plugin without including it in
+	# a full build of OBS Studio.
+    include(GNUInstallDirs)
 
-	set_target_properties(input-overlay PROPERTIES PREFIX "")
+    set_target_properties(input-overlay PROPERTIES PREFIX "")
 
-	file(GLOB locale_files data/locale/*.ini)
+    file(GLOB locale_files data/locale/*.ini)
 
-        set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
-		OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+    set(CMAKE_INSTALL_DEFAULT_DIRECTORY_PERMISSIONS
+        OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_WRITE GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
-	install(TARGETS input-overlay LIBRARY
-		DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins"
-		PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
+    install(TARGETS input-overlay LIBRARY
+        DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/obs-plugins"
+        PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 
-	install(FILES ${locale_files}
-		DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/input-overlay/locale")
+    install(FILES ${locale_files}
+        DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/obs/obs-plugins/input-overlay/locale")
+else()
+    # There isn't much need for Windows to build separately.
+    install_obs_plugin_with_data(input-overlay data)
 endif()
-# --- End of section ---

--- a/hook/gamepad-hook.cpp
+++ b/hook/gamepad-hook.cpp
@@ -93,6 +93,15 @@ void* hook_method(void*)
                 case PAD_AXIS_RT:
                     pad.set_key(axis > 0.3f, PAD_RT);
                     break;
+                /* In case the dpad is a hat */
+                case PAD_AXIS_DX:
+                    pad.set_key(axis < -0.3f, PAD_DPAD_LEFT);
+                    pad.set_key(axis > 0.3f, PAD_DPAD_RIGHT);
+                    break;
+                case PAD_AXIS_DY:
+                    pad.set_key(axis < -0.3f, PAD_DPAD_UP);
+                    pad.set_key(axis > 0.3f, PAD_DPAD_DOWN);
+                    break;
                 case PAD_AXIS_LX:
                     pad.l_x = axis;
                     break;

--- a/util/util.hpp
+++ b/util/util.hpp
@@ -206,6 +206,8 @@
 #define PAD_AXIS_RX			3
 #define PAD_AXIS_RY			4
 #define PAD_AXIS_RT			5
+#define PAD_AXIS_DX			6
+#define PAD_AXIS_DY			7
 
 // Get default keynames from a libuiohook keycode
 const char* key_to_text(int key_code);


### PR DESCRIPTION
Hiya. I know you're doing work on master branch to make things better for the future, so I made some fixes to the legacy branch so Linux users can benefit right away.

The first change is that I updated CMakeLists.txt so that the plugin does not have to be compiled alongside the entirety of OBS Studio. I adapted a lot from palakis's obs-websocket plugin, because that one compiles on its own just fine. This is really important so that a Flatpak package can be submitted for this plugin.

The second change is to handle cases where the d-pad is represented as a hat instead of four buttons by simply mapping the hat to the four buttons, similarly to how the triggers are handled. Otherwise, d-pad inputs aren't registered at all.