### PR TITLE
Add redirect for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,5 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://univrsal.github.io/input-overlay/cct/">
+  </head>
+</html>


### PR DESCRIPTION
When accessing https://univrsal.github.io/input-overlay directly, which can happen, will a 404 page be displayed.

I've gone ahead and added a `index.html` file containing a simple redirect meta towards https://univrsal.github.io/input-overlay/cct/