### PR TITLE
Adjust analog sticks to center.

### DIFF
--- a/projects/plugin/src/util/element/element_analog_stick.cpp
+++ b/projects/plugin/src/util/element/element_analog_stick.cpp
@@ -37,12 +37,12 @@ void element_analog_stick::draw(gs_effect_t *effect, gs_image_file_t *image, sou
     gs_rect *temp;
 
     if (m_side == element_side::LEFT) {
-        pos.y += (settings->data.gamepad_axis[gamepad::axis::LEFT_STICK_Y]) * m_radius * 2;
-        pos.x += (settings->data.gamepad_axis[gamepad::axis::LEFT_STICK_X]) * m_radius * 2;
+        pos.y += ((settings->data.gamepad_axis[gamepad::axis::LEFT_STICK_Y] * 2) - 1) * m_radius;
+        pos.x += ((settings->data.gamepad_axis[gamepad::axis::LEFT_STICK_X] * 2) - 1) * m_radius;
         temp = settings->data.gamepad_buttons[gamepad::button::L_THUMB] ? &m_pressed : &m_mapping;
     } else {
-        pos.y += (settings->data.gamepad_axis[gamepad::axis::RIGHT_STICK_Y]) * m_radius * 2;
-        pos.x += (settings->data.gamepad_axis[gamepad::axis::RIGHT_STICK_X]) * m_radius * 2;
+        pos.y += ((settings->data.gamepad_axis[gamepad::axis::RIGHT_STICK_Y] * 2) - 1) * m_radius;
+        pos.x += ((settings->data.gamepad_axis[gamepad::axis::RIGHT_STICK_X] * 2) - 1) * m_radius;
         temp = settings->data.gamepad_buttons[gamepad::button::R_THUMB] ? &m_pressed : &m_mapping;
     }
     element_texture::draw(effect, image, temp, &pos);


### PR DESCRIPTION
Based on your comment from https://github.com/univrsal/input-overlay/pull/240#issuecomment-1077567429, this is my attempt to fix the issue.  You can check my logic: first we double our input values (changing the range from between 0 and 1, up to 0 and 2), then subtract one -- moving our possible values to between the expected -1 and 1.  Since we already doubled the initial value, I removed the doubling at the end.

It seems to work on my end, with the caveat that you have to tap the analog sticks first.  I'm punching over my head here, and I don't know how to adjust the initial positioning.

Tested on a DualShock 4 controller, which is working fine after some fiddling with the Gamepad Bindings menu except for the dpad not working at all because it's two axes and not buttons.  That's probably *way* too far over my head to fix through sheer stubbornness, but so was this issue until I found you explaining exactly what the problem was.

Thank you for all your work on this project!