### PR TITLE
Option to align to top and repetition counter

### DIFF
--- a/presets/input-history-windows/README.md
+++ b/presets/input-history-windows/README.md
@@ -34,7 +34,7 @@ In the example above:
   - `font-weight: bold;` - Sets text to bold.
   - `font-style: italic;` - Sets text to italic.
   - `background-color: rgba(0, 0, 0, 0);` - Represents red, green, blue, and alpha. Makes the browser's background transparent (which is what you mostly want in the scene).
-- The `.key { ... }` CSS selector: means that all the styles indicated inside the braces are applied to **all elements that has `class="key" in HTML` (the rounded rectangle container for keys)**.
+- The `span.key, span.repeat { ... }` CSS selector: means that all the styles indicated inside the braces are applied to **all elements that has `class="key" or class="repeat" in HTML` (the rounded rectangle container for keys and round repetition counter)**.
   - Note the `!important` after the value of `background-color`. This is sometimes required to override the styles applied within the HTML, and to use this value instead.
 
 ### Hide Specific Keys
@@ -128,8 +128,14 @@ p.key-combination > * {
 ```
 In the example above, `0.5em` is `48px(body:font-size) * 0.5`. Think of it like percentage of the font-size.
 
-### Customize the background of keys
-As stated in the [Basic Styling](#basic-styling), use the `.key` selector to select and style the container of the keys.
+### Customize the background of keys and repeat counters
+As stated in the [Basic Styling](#basic-styling), use the `span.key, span.repeat` selector to select and style the container of the keys and repetition counters.
+
+### Align to the top
+If set to true, keys are top-aligned to the browser source and new keys are added at the top, instead of the bottom.
+```js
+var HISTORY_TOP_ALIGN = true;
+```
 
 ### Change separator character
 Change the character used in between keys.
@@ -141,4 +147,10 @@ var SEPARATOR = "+"; // Change this value in HTML <script>
 To not display a key repeatedly while it's held:
 ```js
 var ONLY_INITIAL_PRESS = true; // Default is false
+```
+
+### Repetition counter interval
+To distinguish between quick consecutive repeated inputs and slow ones, there's a repeat timeout, after which the next repeated input is displayed as a new input and the repetition count is reset. Duration is set in milliseconds (e.g., 1500 = 1.5 seconds).
+```js
+var REPEAT_TIMEOUT = 1500;
 ```

--- a/presets/input-history-windows/input-history-windows.html
+++ b/presets/input-history-windows/input-history-windows.html
@@ -65,6 +65,10 @@
         margin-right: 0.25em;
       }
 
+      span.key, span.repeat {
+        background-color: rgba(0, 0, 0, 0.75);
+      }
+
       span.key {
         display: inline-flex;
         border-radius: 0.25em;
@@ -73,9 +77,16 @@
         line-height: 1em;
 
         padding: 0.25em;
-
-        background-color: rgba(0, 0, 0, 0.75);
         white-space: nowrap;
+      }
+
+      span.repeat {
+        display: inline-flex;
+        margin-left: 0.1em;
+        border-radius: 1em;
+        padding: 0.3em 0.6em;
+
+        font-size: 0.7em;
       }
 
       /* #endregion */
@@ -712,9 +723,7 @@
      * @returns {string} Inline innerHTML equivalent of key
      */
     function getKeyHTML(keycode) {
-      var intcode = parseInt(keycode);
-
-      if (intcode & MOUSEENCODE.flag) // Is this a mouse code?
+      if (keycode & MOUSEENCODE.flag) // Is this a mouse code?
       {
         var mouse = MOUSECODES.get(keycode & MOUSEENCODE.mask);
         if (!!mouse) {
@@ -724,10 +733,10 @@
         return "";
       }
 
-      var key = KEYCODES[intcode];
+      var key = KEYCODES[keycode];
 
       if (!!key) {
-        var icon = KEYICONS[intcode];
+        var icon = KEYICONS[keycode];
 
         if (!!icon) {
           return icon.cloneNode(true).outerHTML;
@@ -743,18 +752,20 @@
     // #region DOM Utils
 
     /**
-     * Gets a {Set} of keycodes, wraps each item in span.key, and joins them by a + (separator)
+     * Gets a {Set} of keycodes, wraps each item in span.key, joins them by
+     * a + (separator), and adds a repeat counter.
      *
      * @returns {HTMLElement} <p> element of key combination
      */
-    function getKeyCombinationElement(setOfKeycodes = new Set()) {
+    function getKeyCombinationElement() {
       try {
-        var innerHTMLofKeys = Array.from(setOfKeycodes)
+        var innerHTMLofKeys = Array.from(_historyCurrentlyPressed)
+          // Convert each keycode into its HTML representation
           .map((keycode) => getKeyHTML(keycode))
           // Filter out non-existing keys in KEYCODES
           .filter((html) => html !== "");
 
-        // Build innerHTMl for the key combination
+        // Build innerHTML for the key combination
         var innerHTMLOfKeyCombination = innerHTMLofKeys
           .map(
             (innerHTML) =>
@@ -763,6 +774,12 @@
           .join(
             createElementWithClass("span", SEPARATOR, ["separator"]).outerHTML
           );
+
+        // Display repetition counter if 2 or higher
+        if (_repeatCount > 1) {
+          innerHTMLOfKeyCombination +=
+            createElementWithClass("span", _repeatCount, ["repeat"]).outerHTML;
+        }
 
         return createElementWithClass("p", innerHTMLOfKeyCombination, [
           "key-combination",
@@ -820,6 +837,12 @@
      * @type {boolean}
      */
     var ONLY_INITIAL_PRESS = false;
+    /**
+     * Only count inputs as repeated if the interval between presses in ms
+     * is less than this value
+     * @type {number}
+     */
+    var REPEAT_TIMEOUT = 1500;
 
     // #endregion
 
@@ -832,13 +855,18 @@
     // History
     var _historyDiv = document.getElementById("history");
     var _historyCurrentlyPressed = new Set();
-    var _addNewCombination = true;
+    var _historyLastPressed = new Set();
+    var _hideLastTimeoutID = undefined;
+    var _hideLastTimeoutElement = null;
+    var _repeatCount = 1;
+    var _repeatTimeoutID = undefined;
     var _mouseButtonsMask = 0;
 
     function onKeyEvent(data) {
       if (data.event_type === "key_typed")
         return;
 
+      // Interpret mouse events
       if (data.event_type.startsWith("mouse")) {
         // Ignore mouse movement and click events
         if (
@@ -857,7 +885,7 @@
           mouse_code_base |= MOUSEENCODE.wheel_rot * (data.rotation > 0); // data.rotation is -1 or 1
 
           updateUI(mouse_code_base, true);
-          // Wheel events don't have a "pressed" state, so remove them after displaying
+          // Wheel events don't have a "pressed" state, so "release" them after displaying
           updateUI(mouse_code_base, false);
         } else if (
             data.event_type === "mouse_pressed" ||
@@ -886,29 +914,54 @@
       }
     }
 
-    function updateUI(keycode, isPressing) {
-      var latestChild = HISTORY_TOP_ALIGN
+    function getLatestChild() {
+      return HISTORY_TOP_ALIGN
         ? _historyDiv.firstElementChild
         : _historyDiv.lastElementChild;
+    }
+
+    function updateUI(keycode, isPressing) {
+      var latestChild = getLatestChild();
 
       if (isPressing) {
         // Is this an already pressed key?
-        if (_historyCurrentlyPressed.has(keycode)) {
-          if (ONLY_INITIAL_PRESS) {
-            // Ignore already pressed key addition
-            return;
-          }
-          // Mark creation of new element for combination
-          _addNewCombination = true;
+        if (_historyCurrentlyPressed.has(keycode)
+            // Are we ignoring key repetition?
+            && ONLY_INITIAL_PRESS) {
+          return;
         }
 
-        _historyCurrentlyPressed.add(keycode);
-        var combinationElement = getKeyCombinationElement(_historyCurrentlyPressed);
+        resetRepeatTimeout();
+
+        // Update pressed keys state while comparing with previously pressed ones
+        // to detect repetition and combinations
+
+        var wasEmpty = _historyCurrentlyPressed.size == 0;
+        var wasSameKeys = compareSets(_historyCurrentlyPressed, _historyLastPressed);
+        _historyCurrentlyPressed.add(keycode); // Register new pressed key
+        var isRepeated = compareSets(_historyCurrentlyPressed, _historyLastPressed);
+
+        // Are we adding to previously pressed keys?
+        // _repeatCount is used to add a new grouping of keys if the previously pressed
+        // ones had been released and pressed more than once, so we don't replace the
+        // repeat counter with the new combination. This allows things like double shift
+        // then shift+a to be displayed separately
+        var isCombination = !wasEmpty && wasSameKeys && !isRepeated && _repeatCount == 1;
+
+        if (isRepeated) {
+          ++_repeatCount;
+        } else {
+          // Store current combination so we can detect future repeated presses
+          _historyLastPressed = new Set(_historyCurrentlyPressed);
+          _repeatCount = 1; // Reset repetitions counter
+        }
+
+        var combinationElement = getKeyCombinationElement();
 
         // If it's a new group of keys, add as new element
-        if (_addNewCombination) {
+        if (!isCombination && !isRepeated) {
           // Fade out elements that were kept because a key was still pressed
-          startRemovingLast(latestChild); 
+          startRemovingLast();
 
           if (HISTORY_TOP_ALIGN) {
             _historyDiv.insertBefore(combinationElement, _historyDiv.firstChild);
@@ -920,7 +973,6 @@
               top: document.body.scrollHeight,
             });
           }
-          _addNewCombination = false;
 
           // Remove oldest element
           if (_historyDiv.children.length > HISTORY_MAX) {
@@ -930,31 +982,66 @@
               _historyDiv.firstElementChild.remove();
           }
         }
-        // If starting key combination, set last item text
+        // Starting key combination or repeating previous ones: set last item text
         else {
           latestChild.innerHTML = combinationElement.innerHTML;
+          cancelRemoveLast(); // Unhide or cancel hiding of last element
         }
       }
-      // If done pressing key combination
+      // If releasing a key
       else {
+        // Update current keys state
         _historyCurrentlyPressed.delete(keycode);
-        _addNewCombination = true; // Next new key has its own group
+
         // Fade element out if no more held keys left
         if (_historyCurrentlyPressed.size == 0) {
-          startRemovingLast(latestChild);
+          startRemovingLast();
         }
       }
     }
 
-    function startRemovingLast(elementToHide) {
+    function startRemovingLast() {
       if (HISTORY_TIMEOUT_ACTIVE) {
         // Add removing class of last key combination
-        if (!elementToHide)
-          return;
-        setTimeout(() => {
+        var elementToHide = getLatestChild();
+        if (!elementToHide || elementToHide.classList.contains("hidden"))
+          return; // History is empty or element is already hidden
+
+        // Store info for if we need to cancel hiding later
+        _hideLastTimeoutElement = elementToHide;
+        _hideLastTimeoutID = setTimeout(() => {
           elementToHide.classList.add("hidden");
         }, HISTORY_TIMEOUT);
       }
+    }
+
+    function cancelRemoveLast() {
+      if (HISTORY_TIMEOUT_ACTIVE) {
+        var elementToUnhide = getLatestChild();
+        if (!elementToUnhide ||
+            _hideLastTimeoutElement != elementToUnhide)
+          return; // History is empty or last element is not setup to hide
+
+        // Unhide if already hidden
+        elementToUnhide.classList.remove("hidden");
+        // Cancel hide timeout
+        clearTimeout(_hideLastTimeoutID);
+      }
+    }
+
+    function resetRepeatTimeout() {
+      if (_repeatTimeoutID !== undefined) {
+        clearTimeout(_repeatTimeoutID);
+      }
+      _repeatTimeoutID = setTimeout(() => {
+        _repeatTimeoutID = undefined;
+        _historyLastPressed.clear();
+      }, REPEAT_TIMEOUT);
+    }
+
+    function compareSets(a, b) { 
+      return a.size === b.size &&
+      [...a].every((elem) => b.has(elem));
     }
 
     function on_data(e) {
@@ -976,7 +1063,7 @@
       };
 
       ws.onclose = () => {
-        // connection closed, discard old websocket and create a new one in 5s
+        // connection closed, discard old websocket and create a new one in 2s
         ws = null;
         setTimeout(start_websocket, 2000);
       };

--- a/presets/input-history-windows/input-history-windows.html
+++ b/presets/input-history-windows/input-history-windows.html
@@ -450,14 +450,19 @@
       //  Cursor Key Zone Begin
       0x0e48: ["VC_UP", "ARROW UP"],
       0x0e4b: ["VC_LEFT", "ARROW LEFT"],
-      0x0e4c: ["VC_CLEAR", ""],
+      // 0x0e4c: ["VC_CLEAR", ""],
       0x0e4d: ["VC_RIGHT", "ARROW RIGHT"],
       0x0e50: ["VC_DOWN", "ARROW DOWN"],
-
+      /* libuihook values */
+      0xe048: ["VC_UP", "ARROW UP"],
+      0xe04b: ["VC_LEFT", "ARROW LEFT"],
+      // 0xe04c: ["VC_CLEAR", ""],
+      0xe04d: ["VC_RIGHT", "ARROW RIGHT"],
+      0xe050: ["VC_DOWN", "ARROW DOWN"],
       /* https://github.com/univrsal/input-overlay/issues/174 */
       0xee48: ["VC_UP", "ARROW UP"], // 0x0e48
       0xee4b: ["VC_LEFT", "ARROW LEFT"], // 0x0e4b
-      0xee4c: ["VC_CLEAR", ""], // 0x0e4c
+      // 0xee4c: ["VC_CLEAR", ""], // 0x0e4c
       0xee4d: ["VC_RIGHT", "ARROW RIGHT"], // 0x0e4d
       0xee50: ["VC_DOWN", "ARROW DOWN"], // 0x0e50
       //  Cursor Key Zone End
@@ -620,6 +625,11 @@
       0x0e4b: document.getElementById("SVG_VC_LEFT"), // ARROW LEFT
       0x0e4d: document.getElementById("SVG_VC_RIGHT"), // ARROW RIGHT
       0x0e50: document.getElementById("SVG_VC_DOWN"), // ARROW DOWN
+      /* libuihook values */
+      0xe048: document.getElementById("SVG_VC_UP"), // ARROW UP
+      0xe04b: document.getElementById("SVG_VC_LEFT"), // ARROW LEFT
+      0xe04d: document.getElementById("SVG_VC_RIGHT"), // ARROW RIGHT
+      0xe050: document.getElementById("SVG_VC_DOWN"), // ARROW DOWN
       /* https://github.com/univrsal/input-overlay/issues/174 */
       0xee48: document.getElementById("SVG_VC_UP"), // ARROW UP
       0xee4b: document.getElementById("SVG_VC_LEFT"), // ARROW LEFT
@@ -683,11 +693,11 @@
       ],
       [
         MOUSEENCODE.wheel | MOUSEENCODE.wheel_x,
-        document.getElementById("SVG_MOUSE_WHEELRIGHT").outerHTML
+        document.getElementById("SVG_MOUSE_WHEELLEFT").outerHTML
       ],
       [
         MOUSEENCODE.wheel | MOUSEENCODE.wheel_x| MOUSEENCODE.wheel_rot,
-        document.getElementById("SVG_MOUSE_WHEELLEFT").outerHTML
+        document.getElementById("SVG_MOUSE_WHEELRIGHT").outerHTML
       ],
     ]);
 
@@ -870,8 +880,10 @@
         return;
       }
 
-      // Keyboard event                              
-      updateUI(data.keycode, data.event_type === "key_pressed");
+      // Keyboard event
+      if (!!KEYCODES[data.keycode]) { // Prevents white space from unassigned keycodes
+        updateUI(data.keycode, data.event_type === "key_pressed");
+      }
     }
 
     function updateUI(keycode, isPressing) {

--- a/presets/input-history-windows/input-history-windows.html
+++ b/presets/input-history-windows/input-history-windows.html
@@ -24,9 +24,12 @@
         font-size: 48px;
         color: white;
 
+        overflow: hidden;
+      }
+
+      body.bottom-align {
         position: absolute;
         bottom: 0;
-        overflow: hidden;
       }
 
       /* #region History List */
@@ -44,7 +47,7 @@
         transition-duration: 1s;
       }
 
-      p.key-combination {
+      * + p.key-combination {
         /* Vertical distance between combinations */
         margin-top: 0.5em;
       }
@@ -792,6 +795,11 @@
      */
     var HISTORY_TIMEOUT = 3500;
     /**
+     * Align history to top of source when true and add newer keys to top.
+     * @type {boolean}
+     */
+    var HISTORY_TOP_ALIGN = false;
+    /**
      * Separator between keys
      * @type {string}
      */
@@ -804,6 +812,12 @@
     var ONLY_INITIAL_PRESS = false;
 
     // #endregion
+
+    // Vertical align setup
+    if (!HISTORY_TOP_ALIGN)
+    {
+      document.body.classList.add(["bottom-align"]);
+    }
 
     // History
     var _historyDiv = document.getElementById("history");
@@ -861,6 +875,10 @@
     }
 
     function updateUI(keycode, isPressing) {
+      var latestChild = HISTORY_TOP_ALIGN
+        ? _historyDiv.firstElementChild
+        : _historyDiv.lastElementChild;
+
       if (isPressing) {
         // Is this an already pressed key?
         if (_historyCurrentlyPressed.has(keycode)) {
@@ -878,13 +896,31 @@
         // If it's a new group of keys, add as new element
         if (_addNewCombination) {
           // Fade out elements that were kept because a key was still pressed
-          startRemovingLast(); 
-          _historyDiv.appendChild(combinationElement);
+          startRemovingLast(latestChild); 
+
+          if (HISTORY_TOP_ALIGN) {
+            _historyDiv.insertBefore(combinationElement, _historyDiv.firstChild);
+          } else {
+            _historyDiv.appendChild(combinationElement);
+
+            // Scroll down
+            scrollTo({
+              top: document.body.scrollHeight,
+            });
+          }
           _addNewCombination = false;
+
+          // Remove oldest element
+          if (_historyDiv.children.length > HISTORY_MAX) {
+            if (HISTORY_TOP_ALIGN)
+              _historyDiv.lastElementChild.remove();
+            else
+              _historyDiv.firstElementChild.remove();
+          }
         }
         // If starting key combination, set last item text
         else {
-          _historyDiv.lastElementChild.innerHTML = combinationElement.innerHTML;
+          latestChild.innerHTML = combinationElement.innerHTML;
         }
       }
       // If done pressing key combination
@@ -893,24 +929,14 @@
         _addNewCombination = true; // Next new key has its own group
         // Fade element out if no more held keys left
         if (_historyCurrentlyPressed.size == 0) {
-          startRemovingLast();
+          startRemovingLast(latestChild);
         }
       }
-
-      // Remove first element
-      if (_historyDiv.children.length > HISTORY_MAX)
-        _historyDiv.firstChild.remove();
-
-      // Scroll down
-      scrollTo({
-        top: document.body.scrollHeight,
-      });
     }
 
-    function startRemovingLast() {
+    function startRemovingLast(elementToHide) {
       if (HISTORY_TIMEOUT_ACTIVE) {
         // Add removing class of last key combination
-        var elementToHide = _historyDiv.lastElementChild;
         if (!elementToHide)
           return;
         setTimeout(() => {


### PR DESCRIPTION
## Add option to align input history to top
Default state is off to keep previous behavior. If on, new keys are added to the top, instead of bottom of the page.

### CSS
- Move body position and bottom settings to `body.bottom-align` class, to apply it only when aligned to the bottom.
- Vertical margin is only applied to keys with another one before them.

### Script
- Add `HISTORY_TOP_ALIGN` option.
- Add `bottom-align` style class to `body` when `HISTORY_TOP_ALIGN` is true.
- Refactored `updateUI` function:
  - To use `HISTORY_TOP_ALIGN` state and add/remove elements accordingly from the top or the bottom of the body.
  - Scroll is only applied if aligned to the bottom.
- `startRemovingLast` now takes a parameter to tell it which element to remove, so the correct element can be computed a single time inside `updateUI`.

## Add `libuihook` arrow keycodes and fix mirrored side-scroll icons
- Add arrow keycodes that match `libuihook` values.
- Fix mirrored mouse side-scroll icons.
- Hide "arrow clear" keycodes.
- Prevent hidden/unknown keycodes from adding blank spaces to history or being handled at all.

## Add repeated input count
Repeated key presses (optionally, held keys too) now generate a single input in the history, with a counter displaying how many times the key/combination was pressed.

There's a time to reset the counter, after which another repeated input is added as a new input, making it easier to distinguish quick consecutive inputs from slower ones.

### CSS
- Add `span.repeat` selector to customize counter.
- Move `background-color` to shared `span.key, span.repeat` selector to have their background color defined a single time.

### Script
- Add `_historyLastPressed` set to store previous keys. With this we're able to distinguish repeated key presses.
- Modify `updateUI` function to support repetition counting.
- Add logic to cancel/undo hiding of previous combination HTML elements, so we can add counters to them if they're repeated.
- Don't use `parseInt` for keycodes. They're already `int` in the JSON parsed from the websocket events.
- Replace function parameters for global variables where that's all they were.
- Remove variable `_addNewCombination`. Decide whether to add new elements from repetition and key-combination detection instead by comparing current and previous (new) set of pressed keys.

## Update README with new features
- Add instructions for repeat counter and vertical alignment.
- Update instructions for key background styling, with addition of repeat counters CSS selector.