### PR TITLE
evdev: add mouse support for Wayland overlay

### DIFF
--- a/WAYLAND-EVDEV-TESTED.md
+++ b/WAYLAND-EVDEV-TESTED.md
@@ -1,0 +1,42 @@
+# Wayland evdev validation
+
+This branch contains an experimental validation patch for the `evdev` Wayland input path.
+
+## Tested environment
+
+Validated locally on:
+
+- CachyOS
+- COSMIC Wayland session
+- NVIDIA proprietary driver
+- OBS Studio 32.1.2, custom COSMIC dockfix build
+- `input-overlay` `evdev` branch plus this patch
+
+## What was validated
+
+- Keyboard overlay using an evdev keyboard device
+- Mouse overlay using an evdev mouse device
+- Mouse button press/release state
+- Relative mouse movement accumulation
+- OBS preview no longer freezes after avoiding a nested evdev mutex lock
+
+The local test used these devices:
+
+```text
+/dev/input/event2  # SONiX USB DEVICE keyboard
+/dev/input/event5  # USB Gaming Mouse
+```
+
+Stable `/dev/input/by-id` paths are preferred when available because `eventN` numbers can change after reboot or USB replug.
+
+## Known limitations
+
+- Wayland/evdev support is still experimental.
+- OBS must have read permission for the selected `/dev/input/event*` device.
+- Device paths are hardware-specific.
+- This has been validated on one local CachyOS COSMIC Wayland/NVIDIA setup so far.
+- More testing is needed on other compositors, distributions, and devices.
+
+## Why this patch exists
+
+The upstream `evdev` branch handled keyboard state but did not fully merge mouse state into the overlay data path. An initial local mouse patch exposed a deadlock: `overlay::refresh_data()` held the evdev reader mutex and then called helpers that attempted to lock the same mutex again. This branch adds mouse state handling and consumes relative movement while already holding the reader lock.

--- a/src/hook/evdev/evdev_reader.cpp
+++ b/src/hook/evdev/evdev_reader.cpp
@@ -109,6 +109,15 @@ void EvdevReader::set_rel_state(uint16_t rel_code, int32_t value)
     rel_state_[rel_code] = value;
 }
 
+int32_t EvdevReader::take_rel_state_locked(uint16_t rel_code)
+{
+    if (rel_code > EVDEV_REL_MAX)
+        return 0;
+    const auto value = rel_state_[rel_code];
+    rel_state_[rel_code] = 0;
+    return value;
+}
+
 void EvdevReader::reader_thread(const std::string &path)
 {
     int fd = open(path.c_str(), O_RDONLY | O_NONBLOCK);
@@ -156,11 +165,18 @@ void EvdevReader::reader_thread(const std::string &path)
                 switch (ev.type) {
                 case EV_KEY:
                     if (ev.code <= EVDEV_KEY_MAX) {
+                        auto mouse_button = evdev_mouse_to_uiohook(ev.code);
                         if (ev.value == 1) { // pressed
-                            key_state[uihook_code] = true;
+                            if (mouse_button != 0)
+                                mouse_state[mouse_button] = true;
+                            else
+                                key_state[uihook_code] = true;
                             bdebug("Key pressed: evdev code %u, uiohook code %u", ev.code, uihook_code);
                         } else if (ev.value == 0) { // released
-                            key_state[uihook_code] = false;
+                            if (mouse_button != 0)
+                                mouse_state[mouse_button] = false;
+                            else
+                                key_state[uihook_code] = false;
                             bdebug("Key released: evdev code %u, uiohook code %u", ev.code, uihook_code);
                         }
                         // value == 2 is repeat — we keep the key as pressed.
@@ -169,7 +185,7 @@ void EvdevReader::reader_thread(const std::string &path)
 
                 case EV_REL:
                     if (ev.code <= EVDEV_REL_MAX) {
-                        rel_state_[ev.code] = ev.value;
+                        rel_state_[ev.code] += ev.value;
                     }
                     break;
 

--- a/src/hook/evdev/evdev_reader.hpp
+++ b/src/hook/evdev/evdev_reader.hpp
@@ -64,8 +64,14 @@ public:
     /// Reset a relative axis value to zero (useful for one-shot events like
     /// scroll).
     void set_rel_state(uint16_t rel_code, int32_t value);
+
+    /// Return and reset a relative axis value while the caller already holds
+    /// mutex_.
+    int32_t take_rel_state_locked(uint16_t rel_code);
+
     mutable std::mutex mutex_;
     std::unordered_map<uint16_t, bool> key_state{};
+    std::unordered_map<uint16_t, bool> mouse_state{};
 
 private:
     void reader_thread(const std::string &path);

--- a/src/util/overlay.cpp
+++ b/src/util/overlay.cpp
@@ -32,6 +32,9 @@
 #include "log.h"
 #include "../network/remote_connection.hpp"
 #include "obs_util.hpp"
+#include <linux/input.h>
+#include <algorithm>
+#include <limits>
 #include <QFile>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -39,6 +42,14 @@
 
 namespace sources {
 class overlay_settings;
+}
+
+static int16_t add_clamped_mouse_delta(int16_t current, int32_t delta)
+{
+    const auto next = static_cast<int32_t>(current) + delta;
+    return static_cast<int16_t>(
+        std::clamp(next, static_cast<int32_t>(std::numeric_limits<int16_t>::min()),
+                   static_cast<int32_t>(std::numeric_limits<int16_t>::max())));
 }
 
 static const std::unordered_map<uint16_t, uint16_t> keyCodeMap = {
@@ -349,7 +360,16 @@ void overlay::refresh_data()
     if (evdev_active) {
         std::lock_guard<std::mutex> evdev_lock(m_settings->evdev_reader.mutex_);
         local_data::data.m_mutex.lock();
-        local_data::data.keyboard = m_settings->evdev_reader.key_state;
+        if (!m_settings->evdev_reader.key_state.empty())
+            local_data::data.keyboard = m_settings->evdev_reader.key_state;
+        for (const auto &[button, pressed] : m_settings->evdev_reader.mouse_state)
+            local_data::data.mouse[button] = pressed;
+        local_data::data.last_mouse_movement.x = add_clamped_mouse_delta(
+            local_data::data.last_mouse_movement.x,
+            m_settings->evdev_reader.take_rel_state_locked(static_cast<uint16_t>(REL_X)));
+        local_data::data.last_mouse_movement.y = add_clamped_mouse_delta(
+            local_data::data.last_mouse_movement.y,
+            m_settings->evdev_reader.take_rel_state_locked(static_cast<uint16_t>(REL_Y)));
         local_data::data.m_mutex.unlock();
     }
 #else


### PR DESCRIPTION
 ## Summary

  Adds mouse support to the experimental Linux evdev input path used for Wayland testing.

  This patch:

  - Tracks evdev mouse button state separately from keyboard state.
  - Accumulates relative mouse movement (`REL_X`/`REL_Y`) instead of replacing the last value.
  - Merges evdev mouse state into `local_data::data.mouse`.
  - Consumes relative movement while the evdev reader mutex is already held, avoiding the nested-lock deadlock that froze OBS preview
  during local testing.
  - Adds `WAYLAND-EVDEV-TESTED.md` with the tested environment and known limitations.

  ## Tested environment

  Validated locally on:

  - CachyOS
  - COSMIC Wayland session
  - NVIDIA proprietary driver
  - OBS Studio 32.1.2, custom COSMIC dockfix build
  - `input-overlay` `evdev` branch plus this patch

  ## Validated behavior

  - Keyboard overlay via evdev device
  - Mouse overlay via evdev device
  - Mouse button press/release state
  - Relative mouse movement path
  - OBS preview no longer freezes after fixing the nested evdev mutex lock

  Local devices used during validation:

  ```text
  /dev/input/event2  # SONiX USB DEVICE keyboard
  /dev/input/event5  # USB Gaming Mouse

  ## Known limitations

  - Wayland/evdev support is still experimental.
  - OBS must have read permission for the selected /dev/input/event* device.
  - Device paths are hardware-specific; /dev/input/by-id is preferable when available.
  - This has only been validated on one local CachyOS COSMIC Wayland/NVIDIA setup so far.
  - More testing is needed across compositors, distributions, and devices.